### PR TITLE
Support for invoke local

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,6 @@ class ServerlessPlugin {
   }
 
   async afterCreateDeploymentArtifacts(): Promise<void> {
-    // Restore service path
-    this.serverless.config.servicePath = this.originalServicePath
-
     // Copy .build to .serverless
     await fs.copy(
       path.join(this.originalServicePath, buildFolder, serverlessFolder),
@@ -115,8 +112,8 @@ class ServerlessPlugin {
 
     this.serverless.service.package.artifact = path.join(this.originalServicePath, serverlessFolder, path.basename(this.serverless.service.package.artifact))
 
-    // Remove temp build folder
-    fs.removeSync(path.join(this.originalServicePath, buildFolder))
+    // Cleanup after everything is copied
+    await this.cleanup();
   }
 
   async cleanup(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,13 @@ export interface ServerlessInstance {
   service: {
     functions: { [key: string]: ServerlessFunction }
     package: ServerlessPackage
+    getFunction: (name: string) => any
   }
 }
 
 export interface ServerlessOptions {
-
+  function?: string
+  extraServicePath?: string
 }
 
 export interface ServerlessFunction {


### PR DESCRIPTION
This adds support for the lifecycle hooks to make ```sls invoke local -f <funcName>``` work.

This fixes #8 