### PR TITLE
Allow configuring ts out directory suffix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,11 @@ const buildFolder = '.build'
 class ServerlessPlugin {
 
   private originalServicePath: string
-  private tsOutDirSuffix: string = ""
+  private tsOutDirSuffix: string = ''
 
   serverless: ServerlessInstance
   options: ServerlessOptions
-  commands:{ [key: string]: any }
+  commands: { [key: string]: any }
   hooks: { [key: string]: Function }
 
   constructor(serverless: ServerlessInstance, options: ServerlessOptions) {
@@ -89,7 +89,7 @@ class ServerlessPlugin {
     }
 
     // include any "extras" from the "include" section
-    if (this.serverless.service.package.include && this.serverless.service.package.include.length > 0){
+    if (this.serverless.service.package.include && this.serverless.service.package.include.length > 0) {
       const files = await globby(this.serverless.service.package.include)
 
       for (const filename of files) {
@@ -117,7 +117,7 @@ class ServerlessPlugin {
     this.serverless.service.package.artifact = path.join(this.originalServicePath, serverlessFolder, path.basename(this.serverless.service.package.artifact))
 
     // Cleanup after everything is copied
-    await this.cleanup();
+    await this.cleanup()
   }
 
   async cleanup(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface ServerlessInstance {
     functions: { [key: string]: ServerlessFunction }
     package: ServerlessPackage
     getFunction: (name: string) => any
+    custom?: any
   }
 }
 


### PR DESCRIPTION
My project is setup something like this:
```
.
├── serverless.yml
├── src
│   ├── index.ts
│   └── lambdas
│       ├── lambda1.ts
│       └── lambda2.ts
...
```
With entries in the serverless yaml like:
```
functions:
  lambda1:
    handler: src/index.lambda1
    events:
      - http:
          path: lambda1
          method: get
```

With the current setup, this plugin will compile `src/index.ts` into `.build/index.js` which causes an issue with serverless not finding the source for the lambdas.  If I remove the `src/` prefix from the handler in `serverless.yml`, the typescript compiler in the plugin cannot resolve the path to the file (i.e. `index.ts`).

I've hacked this together locally with a new config option for appending a path to the output directory with this PR but I'd love to hear any alternative suggestions if you have them.