### PR TITLE
Use 'package' hook instead of 'deploy'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ class ServerlessPlugin {
 
     this.hooks = {
       'before:offline:start:init': this.beforeCreateDeploymentArtifacts.bind(this),
-      'before:deploy:createDeploymentArtifacts': this.beforeCreateDeploymentArtifacts.bind(this),
-      'after:deploy:createDeploymentArtifacts': this.afterCreateDeploymentArtifacts.bind(this),
+      'before:package:createDeploymentArtifacts': this.beforeCreateDeploymentArtifacts.bind(this),
+      'after:package:createDeploymentArtifacts': this.afterCreateDeploymentArtifacts.bind(this),
       'before:invoke:local:invoke': this.beforeCreateDeploymentArtifacts.bind(this),
       'after:invoke:local:invoke': this.cleanup.bind(this),
     }


### PR DESCRIPTION
The `deploy` hook simply [leverages](https://github.com/serverless/serverless/blob/master/lib/plugins/deploy/deploy.js#L95) the `package` hook. By using the `package` hook instead of `deploy`, you get both for the price of one!

This let's a user use both the `$ sls deploy` and `$ sls package` CLI commands.