### PR TITLE
feat: add support for Serverless node devDeps exclusion feature

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
+    "lodash": "^4.17.4"
+  },
+  "devDependencies": {
     "@types/lodash": "^4.14.63",
-    "lodash": "^4.17.4",
     "serverless-plugin-typescript": "^0.1.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,11 @@ class ServerlessPlugin {
       fs.symlinkSync(path.resolve('node_modules'), path.resolve(path.join(buildFolder, 'node_modules')))
     }
 
+    // include package.json into build so Serverless can exlcude devDeps during packaging
+    if (!fs.existsSync(path.resolve(path.join(buildFolder, 'package.json')))) {
+      fs.symlinkSync(path.resolve('package.json'), path.resolve(path.join(buildFolder, 'package.json')))
+    }
+
     // include any "extras" from the "include" section
     if (this.serverless.service.package.include && this.serverless.service.package.include.length > 0) {
       const files = await globby(this.serverless.service.package.include)


### PR DESCRIPTION
Serverless 0.16.0 introduced a [feature](https://github.com/serverless/serverless/pull/3737) which excludes Node.js dev dependencies from .zip files. The feature uses package.json to find which dependencies can be excluded.

This PR adds code to copy the package.json to the .build folder, so that Serverless can find the package.json file during packaging.