### PR TITLE
Added support for Google Cloud Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ All files from `package/include` will be included in the final build file. See [
 
 ## Usage
 
+### Google Cloud Functions
+
+When using with Google Cloud Functions via the [serverless-google-cloudfunctions](https://github.com/serverless/serverless-google-cloudfunctions)
+plugin, you simply have to provide a `main` field in your `package.json`:
+
+```js
+{
+  // ...
+  "main": "handler.js",
+  // ..
+}
+```
+
+And this plugin will automatically compile your typescript correctly. Note
+that the field must refer to the compiled file name, namely, ending with a `.js`
+extension.
+
+If a `main` field was not found, then this plugin will use `index.js`. Before
+compilation begins, it will check to see that the file indicated exists with a
+`.ts` extension before actually trying to compile it.
+
 ### Automatic compilation
 
 The normal Serverless deploy procedure will automatically compile with Typescript:

--- a/example/package.json
+++ b/example/package.json
@@ -1,4 +1,5 @@
 {
+  "main": "handler.js",
   "dependencies": {
     "lodash": "^4.17.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export class ServerlessPlugin {
   }
 
   get rootFileNames() {
-    return typescript.extractFileNames(this.originalServicePath)
+    return typescript.extractFileNames(this.originalServicePath, this.serverless.service.provider.name, this.functions)
   }
 
   prepare() {
@@ -118,7 +118,6 @@ export class ServerlessPlugin {
       this.serverless.config.servicePath = path.join(this.originalServicePath, buildFolder)
     }
 
-    const tsFileNames = typescript.extractFileNames(this.originalServicePath, this.serverless.service.provider.name, this.functions)
     const tsconfig = typescript.getTypescriptConfig(
       this.originalServicePath,
       this.isWatching ? null : this.serverless.cli
@@ -126,7 +125,7 @@ export class ServerlessPlugin {
 
     tsconfig.outDir = buildFolder
 
-    const emitedFiles = await typescript.run(tsFileNames, tsconfig)
+    const emitedFiles = await typescript.run(this.rootFileNames, tsconfig)
     await this.copyExtras()
     return emitedFiles
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export class ServerlessPlugin {
   }
 
   get rootFileNames() {
-    return typescript.extractFileNames(this.functions)
+    return typescript.extractFileNames(this.originalServicePath)
   }
 
   prepare() {
@@ -118,7 +118,7 @@ export class ServerlessPlugin {
       this.serverless.config.servicePath = path.join(this.originalServicePath, buildFolder)
     }
 
-    const tsFileNames = typescript.extractFileNames(this.functions)
+    const tsFileNames = typescript.extractFileNames(this.originalServicePath, this.serverless.service.provider.name, this.functions)
     const tsconfig = typescript.getTypescriptConfig(
       this.originalServicePath,
       this.isWatching ? null : this.serverless.cli

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export interface ServerlessInstance {
     servicePath: string
   }
   service: {
+    provider: {
+      name: string
+    }
     functions: { [key: string]: ServerlessFunction }
     package: ServerlessPackage
     getAllFunctions: () => string[]

--- a/tests/typescript.extractFileName.test.ts
+++ b/tests/typescript.extractFileName.test.ts
@@ -1,5 +1,6 @@
 import {extractFileNames} from '../src/typescript'
 import {ServerlessFunction} from '../src/types'
+import * as path from 'path'
 
 const functions: { [key: string]: ServerlessFunction } = {
     hello: {
@@ -26,9 +27,9 @@ const functions: { [key: string]: ServerlessFunction } = {
 }
 
 describe('extractFileName', () => {
-    it('get function filenames from serverless service', () => {
+    it('get function filenames from serverless service for a non-google provider', () => {
         expect(
-            extractFileNames(functions),
+            extractFileNames(process.cwd(), 'aws', functions),
         ).toEqual(
             [
                 'my-folder/hello.ts',
@@ -37,5 +38,14 @@ describe('extractFileName', () => {
             ],
         )
     })
-})
 
+    it('get function filename from serverless service for a google provider', () => {
+        expect(
+            extractFileNames(path.join(process.cwd(), 'example'), 'google')
+        ).toEqual(
+            [
+                'handler.ts'
+            ]
+        )
+    })
+})


### PR DESCRIPTION
The Google provider will use the entrypoint not from the definition of the handler function, but instead from the package.json:main field, or via a `index.js` file (See [Google Cloud Docs](https://cloud.google.com/functions/docs/writing/) for a reference).

This change modifies the behaviour of the `extractFileNames` to enforce only discovery of those entry points that are used by the Google Cloud Functions runtime.

These changes are backwards compatible with any existing AWS provider.