### PR TITLE
Rename from ServerlessPlugin to TypeScriptPlugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { watchFiles } from './watchFiles'
 const serverlessFolder = '.serverless'
 const buildFolder = '.build'
 
-export class ServerlessPlugin {
+export class TypeScriptPlugin {
 
   private originalServicePath: string
   private isWatching: boolean
@@ -206,4 +206,4 @@ export class ServerlessPlugin {
 
 }
 
-module.exports = ServerlessPlugin
+module.exports = TypeScriptPlugin


### PR DESCRIPTION
I propose to change the name of the plugin to avoid clashing with other plugins that might accidentally also be called ServerlessPlugin. This just happened to me, as my own plugin (https://github.com/SC5/serverless-plugin-additional-stacks) was also called ServerlessPlugin and these plugins shadowed each other, depending on their order in serverless.yml.

You can see the name of the plugin when using the `sls` command with no options, and apparently it's autodetected from the class name.