### PR TITLE
Handle undefined function package.exclude

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export class TypeScriptPlugin {
         exclude: [],
         include: [],
       }
+      // Add plugin to excluded packages or an empty array if exclude is undefined
       fn.package.exclude = _.uniq([...fn.package.exclude || [], 'node_modules/serverless-plugin-typescript'])
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export class TypeScriptPlugin {
         exclude: [],
         include: [],
       }
-      fn.package.exclude = _.uniq([...fn.package.exclude, 'node_modules/serverless-plugin-typescript'])
+      fn.package.exclude = _.uniq([...fn.package.exclude || [], 'node_modules/serverless-plugin-typescript'])
     }
   }
 


### PR DESCRIPTION
I'm using a service with the package rules:

```yml
package:
  exclude:
    - node_modules/@serverless-chrome/**
```

and then re-including that for only one of the functions to keep the package sizes down with:

```yml
functions:
  hello_world:
    package:
      include:
        - node_modules/@serverless-chrome/**
```

Currently, when I do that I get the error `Cannot read property 'Symbol(Symbol.iterator)' of undefined` because the `prepare` function only sets defaults for `package` if it does not exist at all, and doesn't check that it has both `include` and `exclude`. 

My workaround for that has been to add an arbitrary path to exclude, but I added a default empty array here in case `exclude` is undefined. Let me know if there's anything you'd like me to update on this!