### PR TITLE
Add webpack instructions to 'enabling source maps'

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ yarn add --dev source-map-support
 import 'source-map-support/register'
 ```
 
+If you are using webpack (most likely). Add `devtool: 'source-map'` to `webpack.config.js`:
+```js
+module.exports = {
+  .... snip ....
+  devtool: 'source-map',
+  .... snip ....
+
+}
+```
+
 ## Help & Community [![Slack Status](https://slack.graph.cool/badge.svg)](https://slack.graph.cool)
 
 Join our [Slack community](http://slack.graph.cool/) if you run into issues or have questions. We love talking to you!


### PR DESCRIPTION
I was not able to make the source-maps work following instructions in the readme. So I have updated it with what was needed for me.

After a bit we realized, that an additional step was needed for me, because we are using webpack. Which is the default when using the aws-nodejs-typescript template for generating your lambda.