### PR TITLE
Added support for `serverless run`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,9 @@ export class TypeScriptPlugin {
     this.options = options
 
     this.hooks = {
+      'before:run:run': async () => {
+        await this.compileTs()
+      },
       'before:offline:start': async () => {
         await this.compileTs()
         this.watchAll()


### PR DESCRIPTION
Added hooks to support the new `serverless run` command. Compiling works, but watch mode does not. Probably because of the way that `serverless run` loads the files. 