### PR TITLE
Remove node_modules filter for getSourceFiles

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -91,9 +91,6 @@ export function getSourceFiles(
   const program = ts.createProgram(rootFileNames, options)
   const programmFiles = program.getSourceFiles()
     .map(file => file.fileName)
-    .filter(file => {
-      return file.split(path.sep).indexOf('node_modules') < 0
-    })
   return programmFiles
 }
 


### PR DESCRIPTION
We use `npm link` for a shared directory of sources, which creates a symlink in node_modules. The ts files in this project are directly included, but edits to these files aren't picked up by watchFiles due to this check.

I'm not aware of anything that would break by removing this check, since most things in node_modules will be static. This starts picking up .d.ts files for normal compiled projects, and supports directly included .ts files like we're using.