### PR TITLE
Develpr/add openwhisk sequence support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ServerlessOptions {
 export interface ServerlessFunction {
   handler: string
   package: ServerlessPackage
+  sequence?: string[]
 }
 
 export interface ServerlessPackage {

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -56,7 +56,7 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
         //If this function is a sequence and doesn't have a handler defined we'll filter these out
         .filter(fn => {
           if (fn.sequence && !fn.handler) {
-            return null;
+            return false;
           }
           return true;
         })


### PR DESCRIPTION
Issue #93 involves adding support for OpenWhisk. There may be a number of issues changes required to fully support OpenWhisk. This is a bare minimum I believe, because without this change an exception will always be thrown for OpenWhisk `sequences` if they do not contain a handler. 

In this pull request I filter out functions that have a sequence defined for them only if they also do not have a handler supplied. We essentially "skip" over the TypeScript plugin handling logic in this case and allow other plugins / processes to act accordingly for the particular function.

I also updated the `ServerlessOptions` model to allow for an optional `sequence` to be defined on the class.